### PR TITLE
Dropping the br-host config in its own file

### DIFF
--- a/roles/cobbler_deploy/tasks/main.yml
+++ b/roles/cobbler_deploy/tasks/main.yml
@@ -104,7 +104,7 @@
   copy:
     remote_src: yes
     src: /usr/lib/ipxe/undionly.kpxe
-    dest /tftpboot/undionly.kpxe
+    dest: /tftpboot/undionly.kpxe
 
 - name: Get Cobbler loaders
   command: cobbler get-loaders

--- a/roles/cobbler_deploy/tasks/main.yml
+++ b/roles/cobbler_deploy/tasks/main.yml
@@ -65,7 +65,9 @@
   template: src=templates/dhcp.j2 dest=/etc/cobbler/dhcp.template
 
 - name: Install systemd unit for cobbler
-  command: cp /etc/cobbler/cobblerd.service /etc/systemd/system/
+  copy:
+    src: /etc/cobbler/cobblerd.service
+    dest: /etc/systemd/system/cobblerd.service
 
 - name: Restart apache2 service
   systemd:

--- a/roles/lxc_cobbler/tasks/setup-bridge.yml
+++ b/roles/lxc_cobbler/tasks/setup-bridge.yml
@@ -2,7 +2,7 @@
 - apt: name=bridge-utils state=present
 
 - name: Setup bridge br-host where "{{ lxc_host_default_if }}" connects to this bridge
-  template: src=../templates/interfaces.br-host dest=/etc/network/interfaces
+  template: src=../templates/interfaces.br-host dest=/etc/network/interfaces.d/br-host.cfg
   register: network_bridge
 
 - name: restart_networking

--- a/roles/lxc_cobbler/templates/interfaces.br-host
+++ b/roles/lxc_cobbler/templates/interfaces.br-host
@@ -1,26 +1,13 @@
 # This file describes the network interfaces available on your system
 # and how to activate them. For more information, see interfaces(5).
 
-# The loopback network interface
-auto lo
-iface lo inet loopback
-
-# The primary network interface
-iface {{ lxc_host_default_if }} inet manual
-
 auto br-host
 iface br-host inet static
-address {{ ansible_default_ipv4.address }}
-netmask {{ ansible_default_ipv4.netmask }}
-bridge_ports {{ lxc_host_default_if }}
-bridge_stp off
-bridge_fd 0
-bridge_maxwait 0
-gateway {{ ansible_default_ipv4.gateway }}
-dns-nameservers {{ dns_nameservers }}
-
-# Source interfaces
-# Please check /etc/network/interfaces.d before changing this file
-# as interfaces may have been defined in /etc/network/interfaces.d
-# See LP: #1262951
-source /etc/network/interfaces.d/*.cfg
+    address {{ hostvars[inventory_hostname]['ansible_'+ lxc_host_default_if]['ipv4']['address'] }}
+    netmask {{ hostvars[inventory_hostname]['ansible_'+ lxc_host_default_if]['ipv4']['netmask'] }}
+    bridge_ports {{ lxc_host_default_if }}
+    bridge_stp off
+    bridge_fd 0
+    bridge_maxwait 0
+    gateway {{ hostvars[inventory_hostname]['ansible_'+ lxc_host_default_if]['ipv4']['gateway'] }}
+    dns-nameservers {{ dns_nameservers }}


### PR DESCRIPTION
This change moves the br-host config, into its own file in
/etc/networking/interfaces.d/br-host.cfg. This change will allow
configuration of br-host without overwriting /etc/networking/interfaces.

This change also configures the 'address', 'network' and 'gateway'
attributes from the 'lxc_host_default_if' instead of just using the
ansible_default values.