### PR TITLE
Revert "Dropping the br-host config in its own file"

### DIFF
--- a/roles/cobbler_deploy/tasks/main.yml
+++ b/roles/cobbler_deploy/tasks/main.yml
@@ -85,9 +85,7 @@
     dest: /etc/cobbler/dhcp.template
 
 - name: Install systemd unit for cobbler
-  copy:
-    src: /etc/cobbler/cobblerd.service
-    dest: /etc/systemd/system/cobblerd.service
+  command: cp /etc/cobbler/cobblerd.service /etc/systemd/system/
 
 - name: Restart apache2 service
   systemd:

--- a/roles/lxc_cobbler/tasks/setup-bridge.yml
+++ b/roles/lxc_cobbler/tasks/setup-bridge.yml
@@ -2,7 +2,7 @@
 - apt: name=bridge-utils state=present
 
 - name: Setup bridge br-host where "{{ lxc_host_default_if }}" connects to this bridge
-  template: src=../templates/interfaces.br-host dest=/etc/network/interfaces.d/br-host.cfg
+  template: src=../templates/interfaces.br-host dest=/etc/network/interfaces
   register: network_bridge
 
 - name: restart_networking

--- a/roles/lxc_cobbler/templates/interfaces.br-host
+++ b/roles/lxc_cobbler/templates/interfaces.br-host
@@ -1,13 +1,26 @@
 # This file describes the network interfaces available on your system
 # and how to activate them. For more information, see interfaces(5).
 
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+iface {{ lxc_host_default_if }} inet manual
+
 auto br-host
 iface br-host inet static
-    address {{ hostvars[inventory_hostname]['ansible_'+ lxc_host_default_if]['ipv4']['address'] }}
-    netmask {{ hostvars[inventory_hostname]['ansible_'+ lxc_host_default_if]['ipv4']['netmask'] }}
-    bridge_ports {{ lxc_host_default_if }}
-    bridge_stp off
-    bridge_fd 0
-    bridge_maxwait 0
-    gateway {{ hostvars[inventory_hostname]['ansible_'+ lxc_host_default_if]['ipv4']['gateway'] }}
-    dns-nameservers {{ dns_nameservers }}
+address {{ ansible_default_ipv4.address }}
+netmask {{ ansible_default_ipv4.netmask }}
+bridge_ports {{ lxc_host_default_if }}
+bridge_stp off
+bridge_fd 0
+bridge_maxwait 0
+gateway {{ ansible_default_ipv4.gateway }}
+dns-nameservers {{ dns_nameservers }}
+
+# Source interfaces
+# Please check /etc/network/interfaces.d before changing this file
+# as interfaces may have been defined in /etc/network/interfaces.d
+# See LP: #1262951
+source /etc/network/interfaces.d/*.cfg


### PR DESCRIPTION
This needs to be re-designed, current automation expects lxc_host_default_if to be a default gw interface, which is then moved to br-host. Applying this patch didn't works as it leaves lxc_host_default_if configured with same ip address as bridge interface, also ```{{ hostvars[inventory_hostname]['ansible_'+ lxc_host_default_if]['ipv4']['gateway']``` attribute doesn't exists.

Reverts urosorozel/ansible_cobbler#1